### PR TITLE
Enable cross account and region support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(OUT_DIR)/adapter: $(src_deps)
 docker-build: verify-apis test
 	cp deploy/Dockerfile $(TEMP_DIR)/Dockerfile
 
-	docker run -v $(TEMP_DIR):/build -v $(shell pwd):/go/src/github.com/awslabs/k8s-cloudwatch-adapter -e GOARCH=amd64 -e GOFLAGS="$(GOFLAGS)" -w /go/src/github.com/awslabs/k8s-cloudwatch-adapter $(GOIMAGE) /bin/bash -c "\
+	docker run --rm -v $(TEMP_DIR):/build -v $(shell pwd):/go/src/github.com/awslabs/k8s-cloudwatch-adapter -e GOARCH=amd64 -e GOFLAGS="$(GOFLAGS)" -w /go/src/github.com/awslabs/k8s-cloudwatch-adapter $(GOIMAGE) /bin/bash -c "\
 		CGO_ENABLED=0 GO111MODULE=on go build -o /build/adapter cmd/adapter/adapter.go"
 
 	docker build -t $(REGISTRY)/$(IMAGE):$(VERSION) $(TEMP_DIR)
@@ -44,7 +44,7 @@ else
 endif
 
 test:
-	CGO_ENABLED=0 GO111MODULE=on go test ./pkg/...
+	CGO_ENABLED=0 GO111MODULE=on go test -cover ./pkg/...
 
 clean:
 	rm -rf ${OUT_DIR} vendor

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.33.5
 	github.com/kubernetes-incubator/custom-metrics-apiserver v0.0.0-20200323093244-5046ce1afe6b
 	github.com/pkg/errors v0.9.1
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 	k8s.io/apimachinery v0.17.7
 	k8s.io/apiserver v0.17.7 // indirect
 	k8s.io/client-go v0.17.7

--- a/pkg/apis/metrics/v1alpha1/externalmetric.go
+++ b/pkg/apis/metrics/v1alpha1/externalmetric.go
@@ -27,6 +27,12 @@ type MetricSeriesSpec struct {
 	// Name specifies the series name.
 	Name string `json:"name"`
 
+	// RoleARN indicate the ARN of IAM role to assume, this metric will be retrieved using this role.
+	RoleARN string `json:"roleArn"`
+
+	// Region specifies the region where metrics should be retrieved.
+	Region string `json:"region"`
+
 	// Queries specify the CloudWatch metrics query to retrieve data for this series.
 	Queries []MetricDataQuery `json:"queries"`
 }

--- a/pkg/aws/interface.go
+++ b/pkg/aws/interface.go
@@ -2,11 +2,11 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 )
 
-// Client represents a client for Amazon CloudWatch.
-type Client interface {
-
+// CloudWatchManager manages clients for Amazon CloudWatch.
+type CloudWatchManager interface {
 	// Query sends a CloudWatch GetMetricDataInput to CloudWatch API for metric results.
-	QueryCloudWatch(query cloudwatch.GetMetricDataInput) ([]*cloudwatch.MetricDataResult, error)
+	QueryCloudWatch(request v1alpha1.ExternalMetric) ([]*cloudwatch.MetricDataResult, error)
 }

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -4,6 +4,10 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+
 	"k8s.io/klog"
 )
 
@@ -23,4 +27,50 @@ func GetLocalRegion() string {
 
 	// strip the last character from AZ to get region ID
 	return string(body[0 : len(body)-1])
+}
+
+func toCloudWatchQuery(externalMetric *v1alpha1.ExternalMetric) cloudwatch.GetMetricDataInput {
+	queries := externalMetric.Spec.Queries
+
+	cwMetricQueries := make([]*cloudwatch.MetricDataQuery, len(queries))
+	for i, q := range queries {
+		q := q
+		mdq := &cloudwatch.MetricDataQuery{
+			Id:         &q.ID,
+			Label:      &q.Label,
+			ReturnData: &q.ReturnData,
+		}
+
+		if len(q.Expression) == 0 {
+			dimensions := make([]*cloudwatch.Dimension, len(q.MetricStat.Metric.Dimensions))
+			for j := range q.MetricStat.Metric.Dimensions {
+				dimensions[j] = &cloudwatch.Dimension{
+					Name:  &q.MetricStat.Metric.Dimensions[j].Name,
+					Value: &q.MetricStat.Metric.Dimensions[j].Value,
+				}
+			}
+
+			metric := &cloudwatch.Metric{
+				Dimensions: dimensions,
+				MetricName: &q.MetricStat.Metric.MetricName,
+				Namespace:  &q.MetricStat.Metric.Namespace,
+			}
+
+			mdq.MetricStat = &cloudwatch.MetricStat{
+				Metric: metric,
+				Period: &q.MetricStat.Period,
+				Stat:   &q.MetricStat.Stat,
+				Unit:   aws.String(q.MetricStat.Unit),
+			}
+		} else {
+			mdq.Expression = &q.Expression
+		}
+
+		cwMetricQueries[i] = mdq
+	}
+	cwQuery := cloudwatch.GetMetricDataInput{
+		MetricDataQueries: cwMetricQueries,
+	}
+
+	return cwQuery
 }

--- a/pkg/aws/util_test.go
+++ b/pkg/aws/util_test.go
@@ -1,0 +1,140 @@
+package aws
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	api "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+)
+
+func TestToCloudWatchQuery(t *testing.T) {
+	externalMetric := newFullExternalMetric("test")
+	metricRequest := toCloudWatchQuery(externalMetric)
+
+	// Metric Queries
+	if len(metricRequest.MetricDataQueries) != len(externalMetric.Spec.Queries) {
+		t.Errorf("metricRequest Queries = %v, want %v", metricRequest.MetricDataQueries, externalMetric.Spec.Queries)
+	}
+
+	for i, q := range metricRequest.MetricDataQueries {
+		wantQueries := externalMetric.Spec.Queries[i]
+		if q.Expression != nil && *q.Expression != wantQueries.Expression {
+			t.Errorf("metricRequest Expression = %v, want %v", q.Expression, wantQueries.Expression)
+		}
+
+		if *q.Id != wantQueries.ID {
+			t.Errorf("metricRequest ID = %v, want %v", q.Id, wantQueries.ID)
+		}
+
+		if *q.Label != wantQueries.Label {
+			t.Errorf("metricRequest Label = %v, want %v", q.Label, wantQueries.Label)
+		}
+
+		qStat := q.MetricStat
+		wantStat := wantQueries.MetricStat
+
+		if qStat != nil {
+			qMetric := qStat.Metric
+			wantMetric := wantStat.Metric
+
+			if len(qMetric.Dimensions) != len(wantMetric.Dimensions) {
+				t.Errorf("metricRequest Dimensions = %v, want = %v", qMetric.Dimensions, wantMetric.Dimensions)
+			}
+
+			for j, d := range qMetric.Dimensions {
+				if *d.Name != wantMetric.Dimensions[j].Name {
+					t.Errorf("metricRequest Dimension Name = %v, want = %v", *d.Name, wantMetric.Dimensions[j].Name)
+				}
+
+				if *d.Value != wantMetric.Dimensions[j].Value {
+					t.Errorf("metricRequest Dimension Value = %v, want = %v", *d.Value, wantMetric.Dimensions[j].Value)
+				}
+			}
+
+			if *qMetric.MetricName != wantMetric.MetricName {
+				t.Errorf("metricRequest MetricName = %v, want %v", *qMetric.MetricName, wantMetric.MetricName)
+			}
+
+			if *qMetric.Namespace != wantMetric.Namespace {
+				t.Errorf("metricRequest Namespace = %v, want %v", *qMetric.Namespace, wantMetric.Namespace)
+			}
+
+			if *qStat.Period != wantStat.Period {
+				t.Errorf("metricRequest Period = %v, want %v", *qStat.Period, wantStat.Period)
+			}
+
+			if *qStat.Stat != wantStat.Stat {
+				t.Errorf("metricRequest Stat = %v, want %v", *qStat.Stat, wantStat.Stat)
+			}
+
+			if aws.StringValue(qStat.Unit) != wantStat.Unit {
+				t.Errorf("metricRequest Unit = %v, want %v", qStat.Unit, wantStat.Unit)
+			}
+		}
+
+		if *q.ReturnData != wantQueries.ReturnData {
+			t.Errorf("metricRequest ReturnData = %v, want %v", *q.ReturnData, wantQueries.ReturnData)
+		}
+	}
+}
+
+func newFullExternalMetric(name string) *api.ExternalMetric {
+	return &api.ExternalMetric{
+		TypeMeta: metav1.TypeMeta{APIVersion: api.SchemeGroupVersion.String(), Kind: "ExternalMetric"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: api.MetricSeriesSpec{
+			Name:    "Name",
+			RoleARN: "MyRoleARN",
+			Region:  "Region",
+			Queries: []api.MetricDataQuery{
+				{
+					ID:         "query1",
+					Expression: "query2/query3",
+				},
+				{
+					ID: "query2",
+					MetricStat: api.MetricStat{
+						Metric: api.Metric{
+							Dimensions: []api.Dimension{{
+								Name:  "DimensionName1",
+								Value: "DimensionValue1",
+							}},
+							MetricName: "metricName1",
+							Namespace:  "namespace1",
+						},
+						Period: 60,
+						Stat:   "Average",
+						Unit:   "Bytes",
+					},
+					ReturnData: true,
+				},
+				{
+					ID: "query3",
+					MetricStat: api.MetricStat{
+						Metric: api.Metric{
+							Dimensions: []api.Dimension{{
+								Name:  "DimensionName2",
+								Value: "DimensionValue2",
+							},
+								{
+									Name:  "DimensionName3",
+									Value: "DimensionValue3",
+								}},
+							MetricName: "metricName2",
+							Namespace:  "namespace2",
+						},
+						Period: 60,
+						Stat:   "Sum",
+						Unit:   "Count",
+					},
+					ReturnData: false,
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -29,7 +29,7 @@ func NewController(externalMetricInformer informers.ExternalMetricInformer, metr
 		metricHandler:        metricHandler,
 	}
 
-	// wire up enque step.  This provides a hook for testing enqueue step
+	// wire up enqueue step. This provides a hook for testing enqueue step
 	controller.enqueuer = controller.enqueueExternalMetric
 
 	klog.Info("Setting up external metric event handlers")

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -3,8 +3,6 @@ package controller
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	listers "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/listers/metrics/v1alpha1"
 	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/metriccache"
 
@@ -14,7 +12,7 @@ import (
 	"k8s.io/klog"
 )
 
-// Handler processes the events from the controler for external metrics
+// Handler processes the events from the controller for external metrics
 type Handler struct {
 	externalmetricLister listers.ExternalMetricLister
 	metriccache          *metriccache.MetricCache
@@ -67,52 +65,8 @@ func (h *Handler) handleExternalMetric(ns, name string, queueItem namespacedQueu
 	}
 
 	klog.V(2).Infof("externalMetricInfo: %v", externalMetricInfo)
-	queries := externalMetricInfo.Spec.Queries
-
-	// If changing logic in this block ensure changes are duplicated in
-	// `pkg/client.Query()`
-	cwMetricQueries := make([]*cloudwatch.MetricDataQuery, len(queries))
-	for i, q := range queries {
-		q := q
-		mdq := &cloudwatch.MetricDataQuery{
-			Id:         &q.ID,
-			Label:      &q.Label,
-			ReturnData: &q.ReturnData,
-		}
-
-		if len(q.Expression) == 0 {
-			dimensions := make([]*cloudwatch.Dimension, len(q.MetricStat.Metric.Dimensions))
-			for j := range q.MetricStat.Metric.Dimensions {
-				dimensions[j] = &cloudwatch.Dimension{
-					Name:  &q.MetricStat.Metric.Dimensions[j].Name,
-					Value: &q.MetricStat.Metric.Dimensions[j].Value,
-				}
-			}
-
-			metric := &cloudwatch.Metric{
-				Dimensions: dimensions,
-				MetricName: &q.MetricStat.Metric.MetricName,
-				Namespace:  &q.MetricStat.Metric.Namespace,
-			}
-
-			mdq.MetricStat = &cloudwatch.MetricStat{
-				Metric: metric,
-				Period: &q.MetricStat.Period,
-				Stat:   &q.MetricStat.Stat,
-				Unit:   aws.String(q.MetricStat.Unit),
-			}
-		} else {
-			mdq.Expression = &q.Expression
-		}
-
-		cwMetricQueries[i] = mdq
-	}
-	cwQuery := cloudwatch.GetMetricDataInput{
-		MetricDataQueries: cwMetricQueries,
-	}
-
 	klog.V(2).Infof("adding to cache item '%s' in namespace '%s'", name, ns)
-	h.metriccache.Update(queueItem.Key(), name, cwQuery)
+	h.metriccache.Update(queueItem.Key(), name, *externalMetricInfo)
 
 	return nil
 }

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	api "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/metriccache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +37,7 @@ func TestExternalMetricValueIsStored(t *testing.T) {
 		t.Errorf("error after processing = %v, want %v", err, nil)
 	}
 
-	metricRequest, exists := metriccache.GetCloudWatchRequest(externalMetric.Namespace, externalMetric.Name)
+	metricRequest, exists := metriccache.GetExternalMetric(externalMetric.Namespace, externalMetric.Name)
 
 	if exists == false {
 		t.Errorf("exist = %v, want %v", exists, true)
@@ -65,13 +63,13 @@ func TestShouldBeAbleToStoreCustomAndExternalWithSameNameAndNamespace(t *testing
 		t.Errorf("error after processing = %v, want %v", err, nil)
 	}
 
-	externalRequest, exists := metriccache.GetCloudWatchRequest(externalMetric.Namespace, externalMetric.Name)
+	metricRequest, exists := metriccache.GetExternalMetric(externalMetric.Namespace, externalMetric.Name)
 
 	if exists == false {
 		t.Errorf("exist = %v, want %v", exists, true)
 	}
 
-	validateExternalMetricResult(externalRequest, externalMetric, t)
+	validateExternalMetricResult(metricRequest, externalMetric, t)
 }
 
 func TestShouldFailOnInvalidCacheKey(t *testing.T) {
@@ -94,7 +92,7 @@ func TestShouldFailOnInvalidCacheKey(t *testing.T) {
 		t.Errorf("error after processing nil, want non nil")
 	}
 
-	_, exists := metriccache.GetCloudWatchRequest(externalMetric.Namespace, externalMetric.Name)
+	_, exists := metriccache.GetExternalMetric(externalMetric.Namespace, externalMetric.Name)
 
 	if exists == true {
 		t.Errorf("exist = %v, want %v", exists, false)
@@ -112,7 +110,7 @@ func TestWhenExternalItemHasBeenDeleted(t *testing.T) {
 
 	// add the item to the cache then test if it gets deleted
 	queueItem := getExternalKey(externalMetric)
-	metriccache.Update(queueItem.Key(), "test", cloudwatch.GetMetricDataInput{})
+	metriccache.Update(queueItem.Key(), "test", api.ExternalMetric{})
 
 	err := handler.Process(queueItem)
 
@@ -120,7 +118,7 @@ func TestWhenExternalItemHasBeenDeleted(t *testing.T) {
 		t.Errorf("error == %v, want nil", err)
 	}
 
-	_, exists := metriccache.GetCloudWatchRequest(externalMetric.Namespace, externalMetric.Name)
+	_, exists := metriccache.GetExternalMetric(externalMetric.Namespace, externalMetric.Name)
 
 	if exists == true {
 		t.Errorf("exist = %v, want %v", exists, false)
@@ -146,7 +144,7 @@ func TestWhenItemKindIsUnknown(t *testing.T) {
 		t.Errorf("error == %v, want nil", err)
 	}
 
-	_, exists := metriccache.GetCloudWatchRequest("default", "unknown")
+	_, exists := metriccache.GetExternalMetric("default", "unknown")
 
 	if exists == true {
 		t.Errorf("exist = %v, want %v", exists, false)
@@ -169,71 +167,81 @@ func newHandler(storeObjects []runtime.Object, externalMetricsListerCache []*api
 	return handler, metriccache
 }
 
-func validateExternalMetricResult(metricRequest cloudwatch.GetMetricDataInput, externalMetricInfo *api.ExternalMetric, t *testing.T) {
-
-	// Metric Queries
-	if len(metricRequest.MetricDataQueries) != len(externalMetricInfo.Spec.Queries) {
-		t.Errorf("metricRequest Queries = %v, want %v", metricRequest.MetricDataQueries, externalMetricInfo.Spec.Queries)
+func validateExternalMetricResult(metricRequest api.ExternalMetric, externalMetricInfo *api.ExternalMetric, t *testing.T) {
+	spec := metricRequest.Spec
+	wantSpec := externalMetricInfo.Spec
+	if spec.Name != wantSpec.Name {
+		t.Errorf("metricRequest Name = %s, want %s", spec.Name, wantSpec.Name)
 	}
 
-	for i, q := range metricRequest.MetricDataQueries {
-		wantQueries := externalMetricInfo.Spec.Queries[i]
-		if q.Expression != nil && *q.Expression != wantQueries.Expression {
+	if spec.RoleARN != wantSpec.RoleARN {
+		t.Errorf("metricRequest RoleArn = %s, want %s", spec.RoleARN, wantSpec.Name)
+	}
+
+	if spec.Region != wantSpec.Region {
+		t.Errorf("metricRequest Region = %s, want %s", spec.Region, wantSpec.Region)
+	}
+	// Metric Queries
+	if len(spec.Queries) != len(wantSpec.Queries) {
+		t.Errorf("metricRequest Queries = %v, want %v", spec.Queries, wantSpec.Queries)
+	}
+
+	for i, q := range spec.Queries {
+		wantQueries := wantSpec.Queries[i]
+		if q.Expression != wantQueries.Expression {
 			t.Errorf("metricRequest Expression = %v, want %v", q.Expression, wantQueries.Expression)
 		}
 
-		if *q.Id != wantQueries.ID {
-			t.Errorf("metricRequest ID = %v, want %v", q.Id, wantQueries.ID)
+		if q.ID != wantQueries.ID {
+			t.Errorf("metricRequest ID = %v, want %v", q.ID, wantQueries.ID)
 		}
 
-		if *q.Label != wantQueries.Label {
+		if q.Label != wantQueries.Label {
 			t.Errorf("metricRequest Label = %v, want %v", q.Label, wantQueries.Label)
 		}
 
 		qStat := q.MetricStat
 		wantStat := wantQueries.MetricStat
 
-		if qStat != nil {
-			qMetric := qStat.Metric
-			wantMetric := wantStat.Metric
+		qMetric := qStat.Metric
+		wantMetric := wantStat.Metric
 
-			if len(qMetric.Dimensions) != len(wantMetric.Dimensions) {
-				t.Errorf("metricRequest Dimensions = %v, want = %v", qMetric.Dimensions, wantMetric.Dimensions)
+		if len(qMetric.Dimensions) != len(wantMetric.Dimensions) {
+			t.Errorf("metricRequest Dimensions = %v, want = %v", qMetric.Dimensions, wantMetric.Dimensions)
+		}
+
+		for j, d := range qMetric.Dimensions {
+			if d.Name != wantMetric.Dimensions[j].Name {
+				t.Errorf("metricRequest Dimension Name = %v, want = %v", d.Name, wantMetric.Dimensions[j].Name)
 			}
 
-			for j, d := range qMetric.Dimensions {
-				if *d.Name != wantMetric.Dimensions[j].Name {
-					t.Errorf("metricRequest Dimension Name = %v, want = %v", *d.Name, wantMetric.Dimensions[j].Name)
-				}
-
-				if *d.Value != wantMetric.Dimensions[j].Value {
-					t.Errorf("metricRequest Dimension Value = %v, want = %v", *d.Value, wantMetric.Dimensions[j].Value)
-				}
-			}
-
-			if *qMetric.MetricName != wantMetric.MetricName {
-				t.Errorf("metricRequest MetricName = %v, want %v", *qMetric.MetricName, wantMetric.MetricName)
-			}
-
-			if *qMetric.Namespace != wantMetric.Namespace {
-				t.Errorf("metricRequest Namespace = %v, want %v", *qMetric.Namespace, wantMetric.Namespace)
-			}
-
-			if *qStat.Period != wantStat.Period {
-				t.Errorf("metricRequest Period = %v, want %v", *qStat.Period, wantStat.Period)
-			}
-
-			if *qStat.Stat != wantStat.Stat {
-				t.Errorf("metricRequest Stat = %v, want %v", *qStat.Stat, wantStat.Stat)
-			}
-
-			if aws.StringValue(qStat.Unit) != wantStat.Unit {
-				t.Errorf("metricRequest Unit = %v, want %v", qStat.Unit, wantStat.Unit)
+			if d.Value != wantMetric.Dimensions[j].Value {
+				t.Errorf("metricRequest Dimension Value = %v, want = %v", d.Value, wantMetric.Dimensions[j].Value)
 			}
 		}
 
-		if *q.ReturnData != wantQueries.ReturnData {
-			t.Errorf("metricRequest ReturnData = %v, want %v", *q.ReturnData, wantQueries.ReturnData)
+		if qMetric.MetricName != wantMetric.MetricName {
+			t.Errorf("metricRequest MetricName = %v, want %v", qMetric.MetricName, wantMetric.MetricName)
+		}
+
+		if qMetric.Namespace != wantMetric.Namespace {
+			t.Errorf("metricRequest Namespace = %v, want %v", qMetric.Namespace, wantMetric.Namespace)
+		}
+
+		if qStat.Period != wantStat.Period {
+			t.Errorf("metricRequest Period = %v, want %v", qStat.Period, wantStat.Period)
+		}
+
+		if qStat.Stat != wantStat.Stat {
+			t.Errorf("metricRequest Stat = %v, want %v", qStat.Stat, wantStat.Stat)
+		}
+
+		if qStat.Unit != wantStat.Unit {
+			t.Errorf("metricRequest Unit = %v, want %v", qStat.Unit, wantStat.Unit)
+		}
+
+		if q.ReturnData != wantQueries.ReturnData {
+			t.Errorf("metricRequest ReturnData = %v, want %v", q.ReturnData, wantQueries.ReturnData)
 		}
 	}
 
@@ -247,7 +255,9 @@ func newFullExternalMetric(name string) *api.ExternalMetric {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: api.MetricSeriesSpec{
-			Name: "Name",
+			Name:    "Name",
+			RoleARN: "MyRoleARN",
+			Region:  "Region",
 			Queries: []api.MetricDataQuery{
 				{
 					ID:         "query1",

--- a/pkg/metriccache/metric_cache.go
+++ b/pkg/metriccache/metric_cache.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+
 	"k8s.io/klog"
 )
 
@@ -32,19 +33,19 @@ func (mc *MetricCache) Update(key string, name string, metricRequest interface{}
 	mc.metricNames[key] = name
 }
 
-// GetCloudWatchRequest retrieves a metric request from the cache
-func (mc *MetricCache) GetCloudWatchRequest(namepace, name string) (cloudwatch.GetMetricDataInput, bool) {
+// GetExternalMetric retrieves an external metric request from the cache
+func (mc *MetricCache) GetExternalMetric(namespace, name string) (v1alpha1.ExternalMetric, bool) {
 	mc.metricMutex.RLock()
 	defer mc.metricMutex.RUnlock()
 
-	key := externalMetricKey(namepace, name)
+	key := externalMetricKey(namespace, name)
 	metricRequest, exists := mc.metricRequests[key]
 	if !exists {
 		klog.V(2).Infof("metric not found %s", key)
-		return cloudwatch.GetMetricDataInput{}, false
+		return v1alpha1.ExternalMetric{}, false
 	}
 
-	return metricRequest.(cloudwatch.GetMetricDataInput), true
+	return metricRequest.(v1alpha1.ExternalMetric), true
 }
 
 // Remove removes a metric request from the cache

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/aws"
@@ -12,25 +11,22 @@ import (
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 )
 
-var nsGroupResource = schema.GroupResource{Resource: "namespaces"}
-
 // cloudwatchProvider is a implementation of provider.MetricsProvider for CloudWatch
 type cloudwatchProvider struct {
-	client   dynamic.Interface
-	mapper   apimeta.RESTMapper
-	cwClient aws.Client
+	client    dynamic.Interface
+	mapper    apimeta.RESTMapper
+	cwManager aws.CloudWatchManager
 
 	valuesLock  sync.RWMutex
 	metricCache *metriccache.MetricCache
 }
 
-// NewCloudWatchProvider returns an instance of testingProvider, along with its restful.WebService
-// that opens endpoints to post new fake metrics
-func NewCloudWatchProvider(client dynamic.Interface, mapper apimeta.RESTMapper, cwClient aws.Client, metricCache *metriccache.MetricCache) provider.ExternalMetricsProvider {
+// NewCloudWatchProvider returns an instance of cloudwatchProvider
+func NewCloudWatchProvider(client dynamic.Interface, mapper apimeta.RESTMapper, cwManager aws.CloudWatchManager, metricCache *metriccache.MetricCache) provider.ExternalMetricsProvider {
 	provider := &cloudwatchProvider{
 		client:      client,
 		mapper:      mapper,
-		cwClient:    cwClient,
+		cwManager:   cwManager,
 		metricCache: metricCache,
 	}
 

--- a/pkg/provider/provider_external.go
+++ b/pkg/provider/provider_external.go
@@ -22,12 +22,12 @@ func (p *cloudwatchProvider) GetExternalMetric(namespace string, metricSelector 
 		return nil, errors.NewBadRequest("label is set to not selectable. this should not happen")
 	}
 
-	cwRequest, found := p.metricCache.GetCloudWatchRequest(namespace, info.Metric)
+	externalRequest, found := p.metricCache.GetExternalMetric(namespace, info.Metric)
 	if !found {
 		return nil, errors.NewBadRequest("no metric query found")
 	}
 
-	metricValue, err := p.cwClient.QueryCloudWatch(cwRequest)
+	metricValue, err := p.cwManager.QueryCloudWatch(externalRequest)
 	if err != nil {
 		klog.Errorf("bad request: %v", err)
 		return nil, errors.NewBadRequest(err.Error())


### PR DESCRIPTION
Support cross account and region by specifying `roleArn` and `region`
respectively in the `externalmetric` spec definition. Using a `roleArn`
the adapter will assume into the specified role to retrieve metrics.

Issue: #8, #30

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
